### PR TITLE
Add trace deep link tool to generate URLs to Honeycomb traces

### DIFF
--- a/src/tools/get-trace-link.test.ts
+++ b/src/tools/get-trace-link.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTraceDeepLinkTool } from "./get-trace-link.js";
+import { handleToolError } from "../utils/tool-error.js";
+
+// Mock the handleToolError function
+vi.mock("../utils/tool-error.js", () => ({
+  handleToolError: vi.fn((error) => ({
+    content: [{ type: "text", text: error.message }],
+    isError: true
+  }))
+}));
+
+describe("createTraceDeepLinkTool", () => {
+  const mockApi = {
+    getEnvironments: vi.fn(),
+    listDatasets: vi.fn(),
+    getVisibleColumns: vi.fn(),
+    getColumnByName: vi.fn(),
+    getTeamSlug: vi.fn().mockResolvedValue("test-team"), // Mock team slug retrieval
+    getAuthInfo: vi.fn().mockResolvedValue({
+      team: { slug: "test-team", name: "Test Team" }
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should generate a basic trace link with required parameters", async () => {
+    const tool = createTraceDeepLinkTool(mockApi as any);
+    const result = await tool.handler({
+      environment: "test-env",
+      dataset: "test-dataset",
+      traceId: "abc123",
+    });
+
+    if (result.content && result.content[0] && result.content[0].text) {
+      const text = result.content[0].text;
+      const parsed = JSON.parse(text);
+      
+      expect(text).toContain("https://ui.honeycomb.io/test-team/environments/test-env/datasets/test-dataset/trace?trace_id=abc123");
+      expect(parsed).toHaveProperty("environment", "test-env");
+      expect(parsed).toHaveProperty("dataset", "test-dataset");
+      expect(parsed).toHaveProperty("traceId", "abc123");
+      expect(parsed).toHaveProperty("team", "test-team");
+      expect(mockApi.getTeamSlug).toHaveBeenCalledWith("test-env");
+    } else {
+      throw new Error("Expected result to have content[0].text");
+    }
+  });
+
+  it("should include span ID when provided", async () => {
+    const tool = createTraceDeepLinkTool(mockApi as any);
+    const result = await tool.handler({
+      environment: "test-env",
+      dataset: "test-dataset",
+      traceId: "abc123",
+      spanId: "span456",
+    });
+
+    if (result.content && result.content[0] && result.content[0].text) {
+      expect(result.content[0].text).toContain("&span=span456");
+    } else {
+      throw new Error("Expected result to have content[0].text");
+    }
+  });
+
+  it("should include timestamps when provided", async () => {
+    const tool = createTraceDeepLinkTool(mockApi as any);
+    const result = await tool.handler({
+      environment: "test-env",
+      dataset: "test-dataset",
+      traceId: "abc123",
+      traceStartTs: 1614556800,
+      traceEndTs: 1614560400,
+    });
+
+    if (result.content && result.content[0] && result.content[0].text) {
+      expect(result.content[0].text).toContain("&trace_start_ts=1614556800");
+      expect(result.content[0].text).toContain("&trace_end_ts=1614560400");
+    } else {
+      throw new Error("Expected result to have content[0].text");
+    }
+  });
+
+  it("should properly URL-encode trace and span IDs", async () => {
+    const tool = createTraceDeepLinkTool(mockApi as any);
+    const result = await tool.handler({
+      environment: "test-env",
+      dataset: "test-dataset",
+      traceId: "trace/with/slashes",
+      spanId: "span with spaces",
+    });
+
+    if (result.content && result.content[0] && result.content[0].text) {
+      expect(result.content[0].text).toContain("trace_id=trace%2Fwith%2Fslashes");
+      expect(result.content[0].text).toContain("&span=span%20with%20spaces");
+    } else {
+      throw new Error("Expected result to have content[0].text");
+    }
+  });
+
+  it("should handle error when required parameters are missing", async () => {
+    const tool = createTraceDeepLinkTool(mockApi as any);
+    
+    // Missing environment
+    await tool.handler({
+      dataset: "test-dataset",
+      traceId: "abc123",
+    } as any);
+    
+    expect(handleToolError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "Missing required parameter: environment"
+    }), "get_trace_link");
+
+    // Missing traceId
+    await tool.handler({
+      environment: "test-env",
+      dataset: "test-dataset",
+    } as any);
+    
+    expect(handleToolError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "Missing required parameter: traceId"
+    }), "get_trace_link");
+  });
+});

--- a/src/tools/get-trace-link.ts
+++ b/src/tools/get-trace-link.ts
@@ -12,7 +12,7 @@ import { TraceDeepLinkSchema } from "../types/schema.js";
 export function createTraceDeepLinkTool(api: HoneycombAPI) {
   return {
     name: "get_trace_link",
-    description: "Generates a direct deep link to a specific trace in the Honeycomb UI. This tool creates a URL that opens a specific distributed trace, optionally positioning to a particular span and time range.",
+    description: "Generates a direct deep link to a specific trace in the Honeycomb UI. This tool creates a URL that opens a specific distributed trace, optionally positioning to a particular span and time range. If no time range is specified, the trace must have been generated within two hours from the current time. If only the start time is provided, the end time is assumed to be 10 minutes from the start time.",
     schema: TraceDeepLinkSchema.shape,
     /**
      * Handler for the get_trace_link tool

--- a/src/tools/get-trace-link.ts
+++ b/src/tools/get-trace-link.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { HoneycombAPI } from "../api/client.js";
+import { handleToolError } from "../utils/tool-error.js";
+import { TraceDeepLinkSchema } from "../types/schema.js";
+
+/**
+ * Tool to generate a deep link to a specific trace in the Honeycomb UI. This tool returns a URL that can be used to directly access a trace, optionally highlighting a specific span and limiting the time range.
+ * 
+ * @param api - The Honeycomb API client
+ * @returns An MCP tool object with name, schema, and handler function
+ */
+export function createTraceDeepLinkTool(api: HoneycombAPI) {
+  return {
+    name: "get_trace_link",
+    description: "Generates a direct deep link to a specific trace in the Honeycomb UI. This tool creates a URL that opens a specific distributed trace, optionally positioning to a particular span and time range.",
+    schema: TraceDeepLinkSchema.shape,
+    /**
+     * Handler for the get_trace_link tool
+     * 
+     * @param params - The parameters for the tool
+     * @returns A URL for direct access to the trace in the Honeycomb UI
+     */
+    handler: async (params: z.infer<typeof TraceDeepLinkSchema>) => {
+      try {
+        // Validate required parameters
+        if (!params.environment) {
+          throw new Error("Missing required parameter: environment");
+        }
+        if (!params.dataset) {
+          throw new Error("Missing required parameter: dataset");
+        }
+        if (!params.traceId) {
+          throw new Error("Missing required parameter: traceId");
+        }
+
+        // Get the team slug for the environment
+        const teamSlug = await api.getTeamSlug(params.environment);
+        
+        // Start building the trace URL
+        let traceUrl = `https://ui.honeycomb.io/${teamSlug}/environments/${params.environment}/trace?trace_id=${encodeURIComponent(params.traceId)}`;
+        
+        // Add optional parameters if provided
+        if (params.spanId) {
+          traceUrl += `&span=${encodeURIComponent(params.spanId)}`;
+        }
+        
+        if (params.traceStartTs) {
+          traceUrl += `&trace_start_ts=${params.traceStartTs}`;
+        }
+        
+        if (params.traceEndTs) {
+          traceUrl += `&trace_end_ts=${params.traceEndTs}`;
+        }
+        
+        // Add dataset parameter for more specific context
+        if (params.dataset) {
+          // Insert the dataset before the trace part in the URL
+          traceUrl = traceUrl.replace(
+            `/trace?`,
+            `/datasets/${encodeURIComponent(params.dataset)}/trace?`
+          );
+        }
+        
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                url: traceUrl,
+                environment: params.environment,
+                dataset: params.dataset,
+                traceId: params.traceId,
+                team: teamSlug
+              }, null, 2),
+            },
+          ],
+          metadata: {
+            environment: params.environment,
+            dataset: params.dataset,
+            traceId: params.traceId,
+            team: teamSlug
+          }
+        };
+      } catch (error) {
+        return handleToolError(error, "get_trace_link");
+      }
+    }
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@ import { createListSLOsTool } from "./list-slos.js";
 import { createGetSLOTool } from "./get-slo.js";
 import { createListTriggersTool } from "./list-triggers.js";
 import { createGetTriggerTool } from "./get-trigger.js";
+import { createTraceDeepLinkTool } from "./get-trace-link.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
@@ -46,7 +47,10 @@ export function registerTools(server: McpServer, api: HoneycombAPI) {
 
     // Trigger tools
     createListTriggersTool(api),
-    createGetTriggerTool(api)
+    createGetTriggerTool(api),
+    
+    // Trace tools
+    createTraceDeepLinkTool(api)
   ];
 
   // Register each tool with the server

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -61,6 +61,20 @@ export interface PromptResponse {
   }[];
 }
 
+export interface AuthResponse {
+  id: string;
+  type: string;
+  api_key_access: Record<string, boolean>;
+  environment?: {
+    name: string;
+    slug: string;
+  };
+  team?: {
+    name: string;
+    slug: string;
+  };
+}
+
 export interface QueryOptions {
   includeSeries?: boolean;
   limit?: number;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -327,3 +327,15 @@ export const GetRecipientSchema = z.object({
   environment: z.string().describe("The Honeycomb environment"),
   recipientId: z.string().describe("The ID of the recipient to retrieve"),
 });
+
+/**
+ * Schema for generating a trace deep link
+ */
+export const TraceDeepLinkSchema = z.object({
+  environment: z.string().describe("The Honeycomb environment"),
+  dataset: z.string().describe("The dataset containing the trace"),
+  traceId: z.string().describe("The unique trace ID"),
+  spanId: z.string().optional().describe("The unique span ID to jump to within the trace"),
+  traceStartTs: z.number().optional().describe("Start timestamp in Unix epoch seconds"),
+  traceEndTs: z.number().optional().describe("End timestamp in Unix epoch seconds"),
+});


### PR DESCRIPTION
This commit adds a new tool for generating deep links to Honeycomb traces. The tool fetches the team slug from the Honeycomb API and constructs a URL that can be used to directly access traces in the Honeycomb UI.

Key features:
- Add AuthResponse interface for Honeycomb API responses
- Implement getAuthInfo and getTeamSlug methods in the API client
- Create TraceDeepLinkSchema for parameter validation
- Implement get_trace_link tool with support for span IDs and time ranges
- Add comprehensive tests for the new functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #15 