### PR TITLE
document __all__ accurately

### DIFF
--- a/src/tools/get-columns.ts
+++ b/src/tools/get-columns.ts
@@ -21,7 +21,7 @@ interface SimplifiedColumn {
 export function createGetColumnsTool(api: HoneycombAPI) {
   return {
     name: "get_columns",
-    description: "Retrieves a list of all columns available in the specified environment, including their names, types, descriptions, and hidden status.",
+    description: "Retrieves a list of all columns available in the specified dataset, including their names, types, descriptions, and hidden status. Note: __all__ is NOT supported as a dataset name -- it is not possible to list all columns in an environment.",
     schema: {
       environment: z.string().describe("The Honeycomb environment"),
       dataset: z.string().describe("The dataset to fetch columns from"),

--- a/src/tools/list-markers.ts
+++ b/src/tools/list-markers.ts
@@ -12,7 +12,7 @@ import { ListMarkersSchema } from "../types/schema.js";
 export function createListMarkersTool(api: HoneycombAPI) {
   return {
     name: "list_markers",
-    description: "Lists available markers (deployment events) for a specific environment. This tool returns a list of all markers available in the specified environment, including their IDs, messages, types, URLs, creation times, start times, and end times.",
+    description: "Lists available markers (deployment events) for a specific dataset or environment. This tool returns a list of all markers available in the specified dataset or environment, including their IDs, messages, types, URLs, creation times, start times, and end times. NOTE: use __all__ as the dataset name to list all markers in the environment.",
     schema: ListMarkersSchema.shape,
     /**
      * Handler for the list_markers tool

--- a/src/tools/list-slos.ts
+++ b/src/tools/list-slos.ts
@@ -23,7 +23,7 @@ interface SimplifiedSLO {
 export function createListSLOsTool(api: HoneycombAPI) {
   return {
     name: "list_slos",
-    description: "Lists available SLOs (Service Level Objectives) for a specific dataset. This tool returns a list of all SLOs available in the specified environment, including their names, descriptions, time periods, and target per million events expected to succeed.",
+    description: "Lists available SLOs (Service Level Objectives) for a specific dataset. This tool returns a list of all SLOs available in the specified environment, including their names, descriptions, time periods, and target per million events expected to succeed. NOTE: __all__ is NOT supported as a dataset name -- it is not possible to list all triggers in an environment.",
     schema: {
       environment: z.string().describe("The Honeycomb environment"),
       dataset: z.string().describe("The dataset to fetch SLOs from"),

--- a/src/tools/list-slos.ts
+++ b/src/tools/list-slos.ts
@@ -23,7 +23,7 @@ interface SimplifiedSLO {
 export function createListSLOsTool(api: HoneycombAPI) {
   return {
     name: "list_slos",
-    description: "Lists available SLOs (Service Level Objectives) for a specific dataset. This tool returns a list of all SLOs available in the specified environment, including their names, descriptions, time periods, and target per million events expected to succeed. NOTE: __all__ is NOT supported as a dataset name -- it is not possible to list all triggers in an environment.",
+    description: "Lists available SLOs (Service Level Objectives) for a specific dataset. This tool returns a list of all SLOs available in the specified environment, including their names, descriptions, time periods, and target per million events expected to succeed. NOTE: __all__ is NOT supported as a dataset name -- it is not possible to list all SLOs in an environment.",
     schema: {
       environment: z.string().describe("The Honeycomb environment"),
       dataset: z.string().describe("The dataset to fetch SLOs from"),

--- a/src/tools/list-triggers.ts
+++ b/src/tools/list-triggers.ts
@@ -21,7 +21,7 @@ interface SimplifiedTrigger {
 }
 
 /**
- * Tool to list triggers (alerts) for a specific dataset. This tool returns a list of all triggers available in the specified environment, including their names, descriptions, thresholds, and other metadata.
+ * Tool to list triggers (alerts) for a specific dataset. This tool returns a list of all triggers available in the specified dataset, including their names, descriptions, thresholds, and other metadata.
  * 
  * @param api - The Honeycomb API client
  * @returns An MCP tool object with name, schema, and handler function
@@ -29,7 +29,7 @@ interface SimplifiedTrigger {
 export function createListTriggersTool(api: HoneycombAPI) {
   return {
     name: "list_triggers",
-    description: "Lists available triggers (alerts) for a specific dataset. This tool returns a list of all triggers available in the specified environment, including their names, descriptions, thresholds, and other metadata.",
+    description: "Lists available triggers (alerts) for a specific dataset. This tool returns a list of all triggers available in the specified dataset, including their names, descriptions, thresholds, and other metadata. NOTE: __all__ is NOT supported as a dataset name -- it is not possible to list all triggers in an environment.",
     schema: {
       environment: z.string().describe("The Honeycomb environment"),
       dataset: z.string().describe("The dataset to fetch triggers from"),


### PR DESCRIPTION
Turns out `__all__` can't be used in SLOs or Triggers at all, nor in columns.

fixes #7 