### PR TITLE
Refactor config system to use environment variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,9 +134,14 @@ jobs:
           echo "Honeycomb API key is set (length: ${#HONEYCOMB_API_KEY})" >> eval/reports/eval-failed.html
         else
           echo "Honeycomb API key is not set!" >> eval/reports/eval-failed.html
+          echo "Make sure HONEYCOMB_API_KEY is set in GitHub secrets and passed to the workflow" >> eval/reports/eval-failed.html
         fi
         echo '</pre>' >> eval/reports/eval-failed.html
         echo '</body></html>' >> eval/reports/eval-failed.html
+        
+        # Print environment variables (excluding secrets) for debugging
+        echo "Environment variables for debugging:"
+        env | grep -v -E "HONEYCOMB_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY" | sort
         
         exit 1
     

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,10 +82,8 @@ jobs:
     - name: Build project for evaluation
       run: pnpm run build
     
-    - name: Create MCP config
-      run: |
-        echo '${{ secrets.MCP_CONFIG }}' > .mcp-honeycomb.json
-        echo "Created MCP config file"
+    - name: Configure MCP environment
+      run: echo "Using environment variable-based configuration"
     
     # Verify the build file exists before running evals
     - name: Verify build file exists
@@ -110,6 +108,8 @@ jobs:
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        # Use Honeycomb API key for environment variable-based config
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
         # Use only limited models for CI to save costs
         EVAL_MODELS: '{"openai":"gpt-4o","anthropic":"claude-3-5-haiku-latest"}'
         EVAL_CONCURRENCY: 2
@@ -130,11 +130,10 @@ jobs:
         echo '<p>The evaluation process encountered an error. Check the logs for details.</p>' >> eval/reports/eval-failed.html
         echo '<h2>Configuration Information</h2>' >> eval/reports/eval-failed.html
         echo '<pre>' >> eval/reports/eval-failed.html
-        if [ -f .mcp-honeycomb.json ]; then
-          echo "Config file exists but may be invalid. First 100 chars:" >> eval/reports/eval-failed.html
-          head -c 100 .mcp-honeycomb.json >> eval/reports/eval-failed.html
+        if [ -n "$HONEYCOMB_API_KEY" ]; then
+          echo "Honeycomb API key is set (length: ${#HONEYCOMB_API_KEY})" >> eval/reports/eval-failed.html
         else
-          echo "Config file not found!" >> eval/reports/eval-failed.html
+          echo "Honeycomb API key is not set!" >> eval/reports/eval-failed.html
         fi
         echo '</pre>' >> eval/reports/eval-failed.html
         echo '</body></html>' >> eval/reports/eval-failed.html

--- a/README.md
+++ b/README.md
@@ -21,51 +21,44 @@ The build artifact goes into the `/build` folder.
 
 ## Honeycomb Configuration
 
-To use this MCP server, you **must** have a `.mcp-honeycomb.json` configuration file. Where it lives depends on how you use the MCP server.
+To use this MCP server, you need to provide Honeycomb API keys via environment variables. There are two ways to configure your Honeycomb environments:
 
-### In a codebase or repo
+### Option 1: Single Environment (Simplest)
 
-Create a configuration file at `.mcp-honeycomb.json` in your repository root.
+Set a single API key for your primary Honeycomb environment:
 
-```json
-{
-  "environments": [
-    {
-      "name": "production",
-      "apiKey": "your_prod_api_key"
-    },
-    {
-      "name": "staging",
-      "apiKey": "your_staging_api_key"
-    }
-  ]
-}
+```bash
+# For MCP configuration
+HONEYCOMB_API_KEY=your_api_key
 ```
 
-You can technically put it in any location that `MCP_HONEYCOMB_CONFIG` points to, but it's recommended to have a config file per codebase.
+The environment name will be automatically detected from the Honeycomb API.
 
-### Via a desktop client like Claude Desktop
+### Option 2: Multiple Environments
 
-If you're using Claude Desktop instead of an IDE, it's best to place a configuration file at `.mcp-honeycomb.json` in the Home directory of your computer.
+Set multiple environment variables for different Honeycomb environments:
 
-```json
-{
-  "environments": [
-    {
-      "name": "production",
-      "apiKey": "your_prod_api_key"
-    },
-    {
-      "name": "staging",
-      "apiKey": "your_staging_api_key"
-    }
-  ]
-}
+```bash
+# For multiple environments
+HONEYCOMB_ENV_PROD_API_KEY=your_prod_api_key
+HONEYCOMB_ENV_STAGING_API_KEY=your_staging_api_key
+HONEYCOMB_ENV_DEV_API_KEY=your_dev_api_key
+```
+
+Each environment will be accessible using the name in the environment variable (e.g., "prod", "staging", "dev").
+
+### Optional Configuration
+
+You can also set an optional API endpoint if you're using a custom Honeycomb instance:
+
+```bash
+# Optional custom API endpoint (defaults to https://api.honeycomb.io)
+HONEYCOMB_API_ENDPOINT=https://your-custom-honeycomb-endpoint.com
 ```
 
 ## MCP Configuration
 
-You'll need to run `node` on the location of the build artifact and specify the location of your Honeycomb MCP config.
+You'll need to run `node` on the location of the build artifact and pass your Honeycomb environment variables:
 
 ```json
 {
@@ -76,14 +69,33 @@ You'll need to run `node` on the location of the build artifact and specify the 
           "/fully/qualified/path/to/honeycomb-mcp/build/index.mjs"
         ],
         "env": {
-          "MCP_HONEYCOMB_CONFIG": "/fully/qualified/path/to/.mcp-honeycomb.json"
+          "HONEYCOMB_API_KEY": "your_api_key"
         }
       }
     }
 }
 ```
 
-While you can technically omit the `env` section if you have a more central installation, we recommend fully qualifying the path, even if it's a central installation.
+For multiple environments:
+
+```json
+{
+    "mcpServers": {
+      "honeycomb": {
+        "command": "node",
+        "args": [
+          "/fully/qualified/path/to/honeycomb-mcp/build/index.mjs"
+        ],
+        "env": {
+          "HONEYCOMB_ENV_PROD_API_KEY": "your_prod_api_key",
+          "HONEYCOMB_ENV_STAGING_API_KEY": "your_staging_api_key"
+        }
+      }
+    }
+}
+```
+
+You can also set these environment variables in your shell environment before starting the MCP client.
 
 The above configuration has been tested with the following clients:
 

--- a/eval/scripts/runner.ts
+++ b/eval/scripts/runner.ts
@@ -85,7 +85,10 @@ export class EvalRunner {
       // This will handle spawning the process internally
       const transport = new StdioClientTransport({
         command,
-        args
+        args,
+        env: {
+          ...process.env,  // Forward all environment variables including HONEYCOMB_API_KEY
+        }
       });
       
       // Connect to the server

--- a/eval/scripts/runner.ts
+++ b/eval/scripts/runner.ts
@@ -83,12 +83,18 @@ export class EvalRunner {
       
       // Create a StdioClientTransport with the command and args
       // This will handle spawning the process internally
+      // Create a clean environment object with only string values
+      const cleanEnv: Record<string, string> = {};
+      Object.entries(process.env).forEach(([key, value]) => {
+        if (value !== undefined) {
+          cleanEnv[key] = value;
+        }
+      });
+      
       const transport = new StdioClientTransport({
         command,
         args,
-        env: {
-          ...process.env,  // Forward all environment variables including HONEYCOMB_API_KEY
-        }
+        env: cleanEnv  // Forward all environment variables including HONEYCOMB_API_KEY
       });
       
       // Connect to the server

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,57 +1,135 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { loadConfig } from "./config.js";
-import fs from "fs";
-import path from "path";
+import { AuthResponse } from "./types/api.js";
 
-vi.mock('fs');
-vi.mock('path');
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
 
 describe("Config", () => {
+  const originalEnv = { ...process.env };
+  
   beforeEach(() => {
     vi.resetAllMocks();
+    process.env = { ...originalEnv }; // Reset env vars before each test
+    
+    // Default mock for fetch to return success with minimal auth response
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        id: "test-id",
+        type: "test",
+        api_key_access: { query: true },
+        team: { name: "Test Team", slug: "test-team" },
+        environment: { name: "Test Env", slug: "test-env" }
+      } as AuthResponse)
+    });
+  });
+  
+  afterEach(() => {
+    process.env = originalEnv; // Restore original env vars
   });
 
   describe("loadConfig", () => {
-    it("loads valid config from file", () => {
-      const config = {
-        environments: [
-          { name: "prod", apiKey: "prod-key" },
-          { name: "dev", apiKey: "dev-key" },
-        ],
-      };
+    it("loads config from HONEYCOMB_API_KEY", async () => {
+      process.env.HONEYCOMB_API_KEY = "test-key";
       
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
-
-      const loaded = loadConfig();
-      expect(loaded).toEqual(config);
+      const config = await loadConfig();
+      
+      expect(config.environments).toHaveLength(1);
+      const env = config.environments[0];
+      if (env) {
+        expect(env.name).toEqual("Test Env"); // Name from auth response
+        expect(env.apiKey).toEqual("test-key");
+        expect(env.teamSlug).toEqual("test-team");
+      }
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.honeycomb.io/1/auth",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Honeycomb-Team": "test-key"
+          })
+        })
+      );
     });
 
-    it("throws on missing config file", () => {
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-      expect(() => loadConfig()).toThrow(/Configuration file not found/);
+    it("loads config from multiple HONEYCOMB_ENV_*_API_KEY variables", async () => {
+      process.env.HONEYCOMB_ENV_PROD_API_KEY = "prod-key";
+      process.env.HONEYCOMB_ENV_STAGING_API_KEY = "staging-key";
+      
+      // Mock fetch to return different responses for different API keys
+      mockFetch
+        .mockImplementationOnce(() => Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            id: "prod-id",
+            type: "test",
+            api_key_access: { query: true },
+            team: { name: "Prod Team", slug: "prod-team" },
+            environment: { name: "Production", slug: "prod" }
+          } as AuthResponse)
+        }))
+        .mockImplementationOnce(() => Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            id: "staging-id",
+            type: "test",
+            api_key_access: { query: true },
+            team: { name: "Staging Team", slug: "staging-team" },
+            environment: { name: "Staging", slug: "staging" }
+          } as AuthResponse)
+        }));
+      
+      const config = await loadConfig();
+      
+      expect(config.environments).toHaveLength(2);
+      expect(config.environments.find(e => e.name === "prod")).toBeDefined();
+      expect(config.environments.find(e => e.name === "staging")).toBeDefined();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it("throws on invalid JSON", () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue("invalid json");
-      expect(() => loadConfig()).toThrow();
+    it("uses custom API endpoint when specified", async () => {
+      process.env.HONEYCOMB_API_KEY = "test-key";
+      process.env.HONEYCOMB_API_ENDPOINT = "https://custom.honeycomb.io";
+      
+      await loadConfig();
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://custom.honeycomb.io/1/auth",
+        expect.any(Object)
+      );
     });
 
-    it("throws on empty environments array", () => {
-      const config = { environments: [] };
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
-      expect(() => loadConfig()).toThrow(/At least one environment/);
+    it("handles auth failure gracefully", async () => {
+      process.env.HONEYCOMB_API_KEY = "invalid-key";
+      
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized"
+      });
+      
+      const config = await loadConfig();
+      
+      // Should still return a config, but without enhanced auth info
+      expect(config.environments).toHaveLength(1);
+      const env = config.environments[0];
+      if (env) {
+        expect(env.apiKey).toEqual("invalid-key");
+        expect(env.name).toEqual("default"); // Didn't get updated
+        expect(env.teamSlug).toBeUndefined(); // Didn't get populated
+      }
     });
 
-    it("throws on missing required fields", () => {
-      const config = {
-        environments: [{ name: "prod" }], // missing apiKey
-      };
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
-      expect(() => loadConfig()).toThrow();
+    it("throws when no environment variables are set", async () => {
+      // Ensure no Honeycomb env vars are set
+      Object.keys(process.env).forEach(key => {
+        if (key.startsWith("HONEYCOMB_")) {
+          delete process.env[key];
+        }
+      });
+      
+      await expect(loadConfig()).rejects.toThrow(/No Honeycomb configuration found/);
     });
   });
 }); 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,58 +1,134 @@
 import { z } from "zod";
-import fs from "fs";
-import path from "path";
+import { AuthResponse } from "./types/api.js";
 
-export const ConfigSchema = z.object({
-  environments: z.array(z.object({
-    name: z.string(),
-    apiKey: z.string(),
-    apiEndpoint: z.string().optional(),
-  })).min(1, "At least one environment must be configured"),
+// Enhanced environment schema with authentication information
+export const EnvironmentSchema = z.object({
+  name: z.string(),
+  apiKey: z.string(),
+  apiEndpoint: z.string().optional(),
+  // Fields that will be populated from the auth endpoint
+  teamSlug: z.string().optional(),
+  teamName: z.string().optional(),
+  environmentSlug: z.string().optional(),
+  permissions: z.record(z.boolean()).optional(),
 });
 
+export const ConfigSchema = z.object({
+  environments: z.array(EnvironmentSchema).min(1, "At least one environment must be configured"),
+});
+
+export type Environment = z.infer<typeof EnvironmentSchema>;
 export type Config = z.infer<typeof ConfigSchema>;
 
-function findConfigFile(): string {
-  // Prioritize current directory configurations
-  const currentDirPaths = [
-    path.join(process.cwd(), ".mcp-honeycomb.json"),
-    ".mcp-honeycomb.json", // May be the same as above depending on how the program is run
-  ];
+/**
+ * Load configuration from environment variables
+ * Supports both HONEYCOMB_ENV_*_API_KEY for multiple environments
+ * and HONEYCOMB_API_KEY for a single environment
+ */
+async function loadFromEnvVars(): Promise<Config> {
+  const environments: Environment[] = [];
+  const envVars = process.env;
+  const defaultApiEndpoint = "https://api.honeycomb.io";
+  const globalApiEndpoint = envVars.HONEYCOMB_API_ENDPOINT;
 
-  // Then check central location and environment variable
-  const otherPaths = [
-    path.join(process.env.HOME || "~", ".mcp-honeycomb.json"),
-    process.env.MCP_HONEYCOMB_CONFIG,
-  ];
+  // Check for multi-environment pattern: HONEYCOMB_ENV_*_API_KEY
+  const envVarRegex = /^HONEYCOMB_ENV_(.+)_API_KEY$/;
+  for (const [key, value] of Object.entries(envVars)) {
+    const match = key.match(envVarRegex);
+    if (match && match[1] && value) {
+      const envName = match[1].toLowerCase();
+      environments.push({
+        name: envName,
+        apiKey: value,
+        apiEndpoint: globalApiEndpoint || defaultApiEndpoint,
+      });
+    }
+  }
 
-  // Combine paths, filtering out any undefined values
-  const configPaths = [...currentDirPaths, ...otherPaths].filter(Boolean);
+  // Check for single environment: HONEYCOMB_API_KEY
+  if (envVars.HONEYCOMB_API_KEY) {
+    environments.push({
+      name: "default", // This will be updated with actual name from auth response
+      apiKey: envVars.HONEYCOMB_API_KEY,
+      apiEndpoint: globalApiEndpoint || defaultApiEndpoint,
+    });
+  }
 
-  const foundPath = configPaths.find(p => p && fs.existsSync(p));
-  if (!foundPath) {
+  if (environments.length === 0) {
     throw new Error(
-      "Configuration file not found. Please create .mcp-honeycomb.json with your environments and API keys"
+      "No Honeycomb configuration found. Please set HONEYCOMB_API_KEY for a single environment " +
+      "or HONEYCOMB_ENV_<NAME>_API_KEY for multiple environments."
     );
   }
-  return foundPath;
+
+  return { environments };
 }
 
-export function loadConfig(): Config {
-  // Try to load from config file
-  const configPath = findConfigFile(); // This will now throw if no file found
-  
+/**
+ * Enhance configuration with data from the Honeycomb API auth endpoint
+ */
+async function enhanceConfigWithAuth(config: Config): Promise<Config> {
+  const enhancedEnvironments: Environment[] = [];
+
+  // Process each environment sequentially to avoid rate limiting
+  for (const env of config.environments) {
+    try {
+      const headers = {
+        "X-Honeycomb-Team": env.apiKey,
+        "Content-Type": "application/json",
+      };
+
+      const response = await fetch(`${env.apiEndpoint}/1/auth`, { headers });
+      
+      if (!response.ok) {
+        throw new Error(`Auth failed for environment ${env.name}: ${response.statusText}`);
+      }
+
+      const authInfo = await response.json() as AuthResponse;
+      
+      enhancedEnvironments.push({
+        ...env,
+        teamSlug: authInfo.team?.slug,
+        teamName: authInfo.team?.name,
+        environmentSlug: authInfo.environment?.slug,
+        // If this is the default environment from HONEYCOMB_API_KEY, update the name
+        name: env.name === "default" && authInfo.environment?.name ? 
+          authInfo.environment.name : env.name,
+        permissions: authInfo.api_key_access,
+      });
+
+      console.error(`Authenticated environment: ${env.name}`);
+    } catch (error) {
+      console.error(`Failed to authenticate environment ${env.name}: ${error instanceof Error ? error.message : String(error)}`);
+      // Still include this environment but without enhancement
+      enhancedEnvironments.push(env);
+    }
+  }
+
+  return { environments: enhancedEnvironments };
+}
+
+/**
+ * Load and validate configuration from environment variables
+ * and enhance with authentication information
+ */
+export async function loadConfig(): Promise<Config> {
   try {
-    const fileConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    return ConfigSchema.parse(fileConfig);
+    // Load initial config from environment variables
+    const config = await loadFromEnvVars();
+    
+    // Enhance with auth information
+    return await enhanceConfigWithAuth(config);
   } catch (error) {
     if (error instanceof z.ZodError) {
       const issues = error.issues.map(i => `  - ${i.path.join('.')}: ${i.message}`).join('\n');
       throw new Error(
-        `Configuration error:\n${issues}\n\nExample config file:\n{\n  "environments": [\n    {\n      "name": "prod",\n      "apiKey": "your_api_key",\n      "apiEndpoint": "https://api.honeycomb.io"\n    }\n  ]\n}`
+        `Configuration error:\n${issues}\n\nPlease set environment variables:\n` +
+        `- HONEYCOMB_API_KEY=your_api_key (for single environment)\n` +
+        `- HONEYCOMB_ENV_PROD_API_KEY=your_prod_api_key (for multiple environments)\n` +
+        `- HONEYCOMB_ENV_STAGING_API_KEY=your_staging_api_key\n` +
+        `- HONEYCOMB_API_ENDPOINT=https://api.honeycomb.io (optional, to override default)`
       );
-    }
-    if (error instanceof SyntaxError) {
-      console.error(`Failed to parse config file ${configPath}`);
     }
     throw error;
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,9 +1,0 @@
-export interface HoneycombEnvironment {
-  name: string;
-  apiKey: string;
-  baseUrl?: string;
-}
-
-export interface HoneycombConfig {
-  environments: HoneycombEnvironment[];
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,9 @@
-export * from "./config.js";
+// Import config types and re-export them
+import { ConfigSchema, EnvironmentSchema } from "../config.js";
+import type { Config, Environment } from "../config.js";
+export { ConfigSchema, EnvironmentSchema };
+export type { Config, Environment };
+
 export * from "./query.js";
 export * from "./column.js";
 export * from "./slo.js";

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -32,7 +32,7 @@ export class HoneycombError extends Error {
 
     return new HoneycombError(
       422,
-      `Query validation failed: ${message}\n\nSuggested next steps:\n- ${contextStr}\n\nPlease verify:\n- The environment name is correct and configured in .mcp-honeycomb.json\n- Your API key is valid\n- The dataset exists and you have access to it\n- Your query parameters are valid`
+      `Query validation failed: ${message}\n\nSuggested next steps:\n- ${contextStr}\n\nPlease verify:\n- The environment name is correct and configured via HONEYCOMB_API_KEY or HONEYCOMB_ENV_*_API_KEY\n- Your API key is valid\n- The dataset exists and you have access to it\n- Your query parameters are valid`
     );
   }
 

--- a/src/utils/tool-error.ts
+++ b/src/utils/tool-error.ts
@@ -43,7 +43,7 @@ export async function handleToolError(
 
   let helpText = `Failed to execute tool '${toolName}': ${errorMessage}\n\n` +
     `Please verify:\n` +
-    `- The environment name is correct and configured in .mcp-honeycomb.json\n` +
+    `- The environment name is correct and configured via HONEYCOMB_API_KEY or HONEYCOMB_ENV_*_API_KEY\n` +
     `- Your API key is valid\n` +
     `- The dataset exists and you have access to it\n` +
     `- Your query parameters are valid\n`;


### PR DESCRIPTION
 ## Summary
  - Replace file-based config with environment variables
  - Add support for HONEYCOMB_API_KEY for single environments
  - Add support for HONEYCOMB_ENV_*_API_KEY pattern for multiple environments
  - Enhance configuration with Honeycomb API authentication data
  - Add permission checking to API client
  - Update documentation and error messages
  - Normalize configuration types across the codebase

  ## Migration
  To migrate from the previous file-based config to the new environment variable-based config:

  1. For single environment setups:
     - Set the HONEYCOMB_API_KEY environment variable with your API key

  2. For multiple environment setups:
     - Set HONEYCOMB_ENV_PROD_API_KEY, HONEYCOMB_ENV_STAGING_API_KEY, etc. for each environment

  3. Optional: Set HONEYCOMB_API_ENDPOINT if you need to override the default API endpoint

  This makes the configuration more secure (avoiding API keys in files), more flexible (supporting multiple patterns), and more powerful (with
  permissions and auto-discovery of environment details).

  ## Test Plan
  - All tests pass: `pnpm test` ✅
  - All type checks pass: `pnpm typecheck` ✅
  - Manually tested with both single and multiple environment setups ✅