### PR TITLE
Preserve evaluation report history in GitHub Pages deployments

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -21,7 +21,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
       
     steps:
-      - name: Download artifact
+      # Checkout the repo to access scripts
+      - name: Checkout repository
+        uses: actions/checkout@v4
+          
+      # Download new reports from artifacts
+      - name: Download new reports artifact
         uses: actions/github-script@v6
         with:
           script: |
@@ -48,20 +53,132 @@ jobs:
             });
             
             const fs = require('fs');
-            fs.writeFileSync('reports.zip', Buffer.from(download.data));
-            
-      - name: Unzip artifact
+            fs.writeFileSync('new-reports.zip', Buffer.from(download.data));
+      
+      # Download current live site to preserve history
+      - name: Download existing reports from GitHub Pages
+        id: download-site
+        continue-on-error: true
         run: |
-          mkdir -p reports
-          unzip reports.zip -d reports
+          SITE_URL="${{ env.GITHUB_PAGES_URL || format('https://{0}.github.io/{1}', github.repository_owner, github.event.repository.name) }}"
+          echo "Attempting to download existing site from: $SITE_URL"
+          mkdir -p existing-site
+          cd existing-site
           
+          # Try to download index.html first to check if site exists
+          if curl -s -f -o index.html "$SITE_URL/index.html"; then
+            echo "Found existing site, downloading reports..."
+            
+            # Download all the report-*.html files listed in the index.html
+            grep -o 'href="report-[^"]*\.html"' index.html | sed 's/href="\([^"]*\)"/\1/g' | while read -r report; do
+              echo "Downloading $report"
+              curl -s -f -o "$report" "$SITE_URL/$report" || echo "Failed to download $report"
+            done
+            
+            echo "::set-output name=existing_site::true"
+            echo "Downloaded $(find . -name 'report-*.html' | wc -l) existing reports"
+          else
+            echo "No existing site found, starting fresh"
+            echo "::set-output name=existing_site::false"
+          fi
+      
+      - name: Unzip new reports
+        run: |
+          mkdir -p new-reports
+          unzip new-reports.zip -d new-reports
+      
+      - name: Merge reports
+        run: |
+          # Create combined directory for all reports
+          mkdir -p combined-reports
+          
+          # Copy existing reports if they were downloaded successfully
+          if [ "${{ steps.download-site.outputs.existing_site }}" == "true" ]; then
+            cp -r existing-site/* combined-reports/ || true
+          fi
+          
+          # Copy new reports, potentially overwriting any duplicates
+          cp -r new-reports/* combined-reports/
+          
+          # Create a list of all reports for debugging
+          find combined-reports -name "report-*.html" | sort > report-list.txt
+          echo "Combined reports directory contains:"
+          cat report-list.txt
+      
+      - name: Update index.html with all reports
+        run: |
+          cd combined-reports
+          
+          # Create a Node.js script to regenerate the index.html
+          cat > update-index.js << 'EOF'
+          const fs = require('fs');
+          
+          // Get all report files
+          const files = fs.readdirSync('.');
+          const reportFiles = files.filter(file => file.startsWith('report-') && file.endsWith('.html'));
+          
+          // Sort by date (newest first)
+          reportFiles.sort((a, b) => b.localeCompare(a));
+          
+          // Generate report links
+          const reportLinks = reportFiles.map((file, index) => {
+            const isLatest = index === 0;
+            const dateMatch = file.match(/report-(.+)\.html/);
+            const dateStr = dateMatch && dateMatch[1] ? dateMatch[1].replace(/-/g, ':').replace('T', ' ').substring(0, 19) : 'Unknown date';
+            
+            return `<li class="${isLatest ? 'latest' : ''}">
+              <a href="${file}">${isLatest ? '📊 Latest: ' : ''}Report from ${dateStr}</a>
+              ${isLatest ? '<small>(This is the most recent evaluation run)</small>' : ''}
+            </li>`;
+          });
+          
+          // Create HTML
+          const html = `<!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Honeycomb MCP Evaluation Reports</title>
+            <style>
+              body { font-family: sans-serif; line-height: 1.6; margin: 0; padding: 20px; color: #333; }
+              .container { max-width: 800px; margin: 0 auto; }
+              h1 { color: #F5A623; border-bottom: 2px solid #F5A623; padding-bottom: 10px; }
+              ul { list-style-type: none; padding: 0; }
+              li { margin: 10px 0; padding: 10px; border-bottom: 1px solid #eee; }
+              a { color: #0066cc; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+              .date { color: #666; font-size: 0.9em; }
+              .latest { background: #fffbf4; border-left: 3px solid #F5A623; padding-left: 15px; }
+            </style>
+          </head>
+          <body>
+            <div class="container">
+              <h1>Honeycomb MCP Evaluation Reports</h1>
+              <p>Select a report to view detailed evaluation results:</p>
+              
+              <ul>
+                ${reportLinks.join('\n                ')}
+              </ul>
+            </div>
+          </body>
+          </html>`;
+          
+          fs.writeFileSync('index.html', html);
+          console.log('Generated index.html with', reportFiles.length, 'reports');
+          EOF
+          
+          node update-index.js
+          
+          # Add a .nojekyll file to disable Jekyll processing
+          touch .nojekyll
+      
       - name: Setup Pages
         uses: actions/configure-pages@v4
         
       - name: Upload to Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: reports
+          path: combined-reports
           
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Enhance GitHub Pages deployment workflow to preserve historical evaluation reports
- Download existing reports from the live site before each new deployment
- Regenerate index.html to include all reports sorted by date

## Test plan
- A GitHub Pages deployment should contain all historical reports, not just the most recent one
- When a new evaluation runs, the previous reports should still be accessible via the index page

🤖 Generated with [Claude Code](https://claude.ai/code)