### PR TITLE
Fix GitHub Pages deploy script to use ES modules

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -52,8 +52,8 @@ jobs:
               archive_format: 'zip'
             });
             
-            const fs = require('fs');
-            fs.writeFileSync('new-reports.zip', Buffer.from(download.data));
+            const { writeFileSync } = await import('fs');
+            writeFileSync('new-reports.zip', Buffer.from(download.data));
       
       # Download current live site to preserve history
       - name: Download existing reports from GitHub Pages
@@ -111,10 +111,10 @@ jobs:
           
           # Create a Node.js script to regenerate the index.html
           cat > update-index.js << 'EOF'
-          const fs = require('fs');
+          import { readdirSync, writeFileSync } from 'fs';
           
           // Get all report files
-          const files = fs.readdirSync('.');
+          const files = readdirSync('.');
           const reportFiles = files.filter(file => file.startsWith('report-') && file.endsWith('.html'));
           
           // Sort by date (newest first)
@@ -163,7 +163,7 @@ jobs:
           </body>
           </html>`;
           
-          fs.writeFileSync('index.html', html);
+          writeFileSync('index.html', html);
           console.log('Generated index.html with', reportFiles.length, 'reports');
           EOF
           


### PR DESCRIPTION
## Summary
- Fixes the GitHub Pages deployment workflow failure caused by CommonJS require() in an ES module context
- Converts CommonJS require() to ES module import syntax in the GitHub workflow Node.js scripts
- Updates both the artifact download step and the index.html generation script

## Test plan
- The GitHub Pages deployment workflow should now execute without the 'require is not defined in ES module scope' error

🤖 Generated with [Claude Code](https://claude.ai/code)