### PR TITLE
feat: add MCP compliance testing workflow

### DIFF
--- a/.github/workflows/mcp-compliance.yml
+++ b/.github/workflows/mcp-compliance.yml
@@ -1,0 +1,138 @@
+name: MCP Compliance Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  compliance-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'pnpm'
+
+    - name: Install pnpm
+      run: npm install -g pnpm
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build server
+      run: pnpm run build
+
+    - name: Clone MCP Validator
+      run: |
+        git clone https://github.com/modelcontextprotocol/mcp-validator.git
+        cd mcp-validator
+        pip install -r requirements.txt
+
+    - name: Run compliance tests
+      env:
+        HONEYCOMB_API_KEY: test_key
+        HONEYCOMB_API_ENDPOINT: http://localhost:8080
+      run: |
+        python -m mcp_testing.scripts.compliance_report \
+          --server-command "node ${{ github.workspace }}/build/index.mjs" \
+          --protocol-version 2025-03-26
+      working-directory: mcp-validator
+
+    - name: Process compliance report
+      id: process-report
+      run: |
+        # Create .github/mcp-compliance directory if it doesn't exist
+        mkdir -p .github/mcp-compliance/reports
+
+        # Get the latest report
+        LATEST_REPORT=$(ls -t mcp-validator/reports/cr_*.md | head -n 1)
+        
+        if [ -f "$LATEST_REPORT" ]; then
+          # Extract compliance percentage
+          COMPLIANCE=$(grep "Compliance Status:" "$LATEST_REPORT" | grep -o "[0-9.]*")
+          
+          # Generate report name with compliance percentage
+          REPORT_NAME="compliance-${COMPLIANCE}pct-$(date +%Y%m%d-%H%M%S).md"
+          
+          # Copy report
+          cp "$LATEST_REPORT" ".github/mcp-compliance/reports/$REPORT_NAME"
+          
+          # Create latest symlink
+          ln -sf "$REPORT_NAME" .github/mcp-compliance/reports/latest.md
+          
+          # Set outputs for use in other steps
+          echo "report_path=.github/mcp-compliance/reports/$REPORT_NAME" >> $GITHUB_OUTPUT
+          echo "compliance=$COMPLIANCE" >> $GITHUB_OUTPUT
+          
+          # Generate badge JSON
+          mkdir -p .github/mcp-compliance/badges
+          cat > .github/mcp-compliance/badges/compliance.json << EOF
+          {
+            "schemaVersion": 1,
+            "label": "mcp-compliance",
+            "message": "${COMPLIANCE}%",
+            "color": $([ $(echo "$COMPLIANCE >= 90" | bc -l) = 1 ] && echo '"success"' || echo '"critical"')
+          }
+          EOF
+        else
+          echo "No report file found!"
+          exit 1
+        fi
+
+    - name: Upload compliance artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: mcp-compliance
+        path: |
+          .github/mcp-compliance/reports/
+          .github/mcp-compliance/badges/
+        retention-days: 90
+
+    - name: Comment PR with Results
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const report = fs.readFileSync('.github/mcp-compliance/reports/latest.md', 'utf8');
+          const summary = report.split('\n').slice(0, 20).join('\n'); // First 20 lines for summary
+          const compliance = '${{ steps.process-report.outputs.compliance }}';
+          
+          const comment = `## MCP Compliance Test Results
+          
+          ![MCP Compliance](https://img.shields.io/badge/mcp--compliance-${compliance}%25-${parseFloat(compliance) >= 90 ? 'success' : 'critical'})
+          
+          ${summary}
+          
+          [Full Report](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})
+          `;
+          
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment
+          });
+
+    - name: Update badges
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "action@github.com"
+        git add .github/mcp-compliance
+        git commit -m "chore: Update MCP compliance report and badges [skip ci]" || echo "No changes to commit"
+        git push 

--- a/reports/compliance-report-manual.md
+++ b/reports/compliance-report-manual.md
@@ -1,0 +1,63 @@
+# Index.Mjs MCP Compliance Report
+
+## Server Information
+
+- **Server Command**: `node /Users/scott/AI/PROTOCOL_STRATEGY/mcp/forked/honeycomb-mcp/build/index.mjs`
+- **Protocol Version**: 2025-03-26
+- **Test Date**: 2025-05-08 12:35:59
+
+## Summary
+
+- **Total Tests**: 36
+- **Passed**: 24 (66.7%)
+- **Failed**: 12 (33.3%)
+
+**Compliance Status**: ❌ Non-Compliant (66.7%)
+
+## Detailed Results
+
+### Passed Tests
+
+| Test | Duration | Message |
+|------|----------|---------|
+| Initialization | 1.06s | Initialization successful |
+| Server Capabilities | 1.09s | Server supports all required capabilities for 2025-03-26 |
+| Async Echo Tool | 1.09s | Echo tool not available (skipping test) |
+| Async Long Running Tool | 1.10s | Sleep tool not available (skipping test) |
+| Async Tool Cancellation | 1.09s | Sleep tool not available (skipping test) |
+| Request Format | 1.09s | Server accepts properly formatted JSON-RPC requests |
+| Response Format | 1.08s | Server returns properly formatted JSON-RPC responses |
+| Notification Format | 1.08s | Server accepts properly formatted JSON-RPC notifications |
+| Http Transport Requirements | 1.09s | Not using HTTP transport, test skipped |
+| Initialization Negotiation | 1.08s | Server correctly negotiated protocol version '2024-11-05' |
+| Capability Declaration | 1.10s | Server correctly declared capabilities: resources, tools, prompts |
+| Logging Capability | 1.08s | Server does not advertise logging capability |
+| Authorization Requirements | 1.09s | Not using HTTP transport, authorization test skipped |
+| Workspace Configuration | 1.09s | Server does not advertise workspace configuration capability |
+| Resources Capability | 1.09s | Server correctly implements empty resources list |
+| Resource Uri Validation | 1.10s | Server correctly implements empty resources list (can't test URI validation) |
+| Async Tools Capability | 1.09s | Server does not advertise async tools capability |
+| Async Tool Calls Validation | 1.08s | Server does not advertise async tools capability |
+| Async Cancellation | 1.09s | Server does not advertise async tools capability |
+| Tools List | 1.09s | Successfully retrieved 14 tools |
+| Tool Functionality | 1.09s | Successfully tested tool: list_datasets |
+| Tool With Invalid Params | 1.10s | Server correctly validates tool parameters |
+| Tools Capability | 1.09s | Server correctly implements tools capability |
+| Tool Schema Validation | 1.09s | Server correctly validates tool parameters against schema for tool 'list_datasets' |
+
+### Failed Tests
+
+| Test | Duration | Error Message |
+|------|----------|--------------|
+| Jsonrpc Batch Support | 6.10s | Batch request failed: Failed to send batch request: No response received from server within 5.0 seconds |
+| Async Tool Support | 1.09s | Server does not advertise async tool support in capabilities |
+| Unique Request Ids | 1.08s | First server/info request failed: Method not found |
+| Error Handling | 1.07s | Server not responsive after error tests |
+| Jsonrpc Batch Support | 6.11s | Batch request failed: Failed to send batch request: No response received from server within 5.0 seconds |
+| Stdio Transport Requirements | 1.08s | Valid message with proper newline delimiter failed: Method not found |
+| Versioning Requirements | 1.09s | Failed to get server info for version check |
+| Server Info Requirements | 1.09s | Server/info request failed: Method not found |
+| Initialization Order | 1.09s | Server didn't properly accept request after initialization: Method not found |
+| Prompts Capability | 1.09s | Failed to test prompts capability: object dict can't be used in 'await' expression |
+| Prompt Arguments Validation | 1.09s | Failed to test prompt arguments validation: object dict can't be used in 'await' expression |
+| Cancellation Validation | 1.09s | Server failed to respond after cancellation tests |


### PR DESCRIPTION
This PR adds automated MCP compliance testing via GitHub Actions.\n\nKey features:\n- Runs compliance tests against protocol version 2025-03-26\n- Generates detailed compliance reports in .github/mcp-compliance/reports/\n- Creates compliance badges showing current status\n- Automatically comments on PRs with test results\n- Retains compliance artifacts for 90 days\n\nThe workflow runs on:\n- Pull requests\n- Pushes to main\n- Manual trigger\n\nThis provides a standardized way to verify and communicate MCP compliance across different server implementations.